### PR TITLE
Correct firmware version in the sidebar

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -603,7 +603,7 @@
                                                     <div class="truncate">
                                                         <p class="truncate text-sm font-medium text-gray-900">Firmware</p>
                                                         <p class="truncate text-sm text-gray-700">
-                                                            <span v-if="selectedNode.firmware">{{ selectedNode.firmware }}</span>
+                                                            <span v-if="selectedNode.firmware_version">{{ selectedNode.firmware_version }}</span>
                                                             <span v-else class="text-gray-500">???</span>
                                                         </p>
                                                     </div>


### PR DESCRIPTION
Node.firmware_version was called node.firmware, so it was never loading.