### PR TITLE
Trace routes are reported in the same way as in phone apps.

### DIFF
--- a/prisma/migrations/20240416014304_add_new_traceroute_columns_and_remove_node_id_column/migration.sql
+++ b/prisma/migrations/20240416014304_add_new_traceroute_columns_and_remove_node_id_column/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `node_id` on the `traceroutes` table. All the data in the column will be lost.
+  - Added the required column `from` to the `traceroutes` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `to` to the `traceroutes` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `want_response` to the `traceroutes` table without a default value. This is not possible if the table is not empty.
+
+*/
+
+-- NOTE: manually added query, to drop existing traceroutes before adding required columns
+TRUNCATE table `traceroutes`;
+
+-- DropIndex
+DROP INDEX `traceroutes_node_id_idx` ON `traceroutes`;
+
+-- AlterTable
+ALTER TABLE `traceroutes` DROP COLUMN `node_id`,
+    ADD COLUMN `from` BIGINT NOT NULL,
+    ADD COLUMN `to` BIGINT NOT NULL,
+    ADD COLUMN `want_response` BOOLEAN NOT NULL;
+
+-- CreateIndex
+CREATE INDEX `traceroutes_to_idx` ON `traceroutes`(`to`);
+
+-- CreateIndex
+CREATE INDEX `traceroutes_from_idx` ON `traceroutes`(`from`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,7 +163,9 @@ model TextMessage {
 
 model TraceRoute {
   id      BigInt @id @default(autoincrement())
-  node_id BigInt
+  from_id BigInt @default(0)
+  to_id   BigInt @default(0)
+  want_response  Boolean @default(true)
   route   Json
 
   channel    Int?
@@ -176,7 +178,8 @@ model TraceRoute {
 
   @@index(created_at)
   @@index(updated_at)
-  @@index(node_id)
+  @@index(from_id)
+  @@index(to_id)
   @@map("traceroutes")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -162,11 +162,11 @@ model TextMessage {
 }
 
 model TraceRoute {
-  id      BigInt @id @default(autoincrement())
-  from_id BigInt @default(0)
-  to_id   BigInt @default(0)
-  want_response  Boolean @default(true)
-  route   Json
+  id            BigInt  @id @default(autoincrement())
+  to            BigInt
+  from          BigInt
+  want_response Boolean
+  route         Json
 
   channel    Int?
   packet_id  BigInt?
@@ -178,8 +178,8 @@ model TraceRoute {
 
   @@index(created_at)
   @@index(updated_at)
-  @@index(from_id)
-  @@index(to_id)
+  @@index(to)
+  @@index(from)
   @@map("traceroutes")
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -282,7 +282,9 @@ app.get('/api/v1/nodes/:nodeId/traceroutes', async (req, res) => {
         }
 
         // get latest traceroutes
-        const traceroutes = await prisma.$queryRaw`SELECT * FROM traceroutes WHERE node_id = ${node.node_id} and JSON_LENGTH(route) > 0 and gateway_id is not null order by id desc limit ${count}`;
+        // We want replies where want_response is false and it will be "to" the
+        // requester.
+        const traceroutes = await prisma.$queryRaw`SELECT * FROM traceroutes WHERE want_response = false and to_id = ${node.node_id} and gateway_id is not null order by id desc limit ${count}`;
 
         res.json({
             traceroutes: traceroutes,

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ app.get('/api/v1/nodes/:nodeId/traceroutes', async (req, res) => {
         // get latest traceroutes
         // We want replies where want_response is false and it will be "to" the
         // requester.
-        const traceroutes = await prisma.$queryRaw`SELECT * FROM traceroutes WHERE want_response = false and to_id = ${node.node_id} and gateway_id is not null order by id desc limit ${count}`;
+        const traceroutes = await prisma.$queryRaw`SELECT * FROM traceroutes WHERE want_response = false and \`to\` = ${node.node_id} and gateway_id is not null order by id desc limit ${count}`;
 
         res.json({
             traceroutes: traceroutes,

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -579,7 +579,9 @@ client.on("message", async (topic, message) => {
 
             if(logKnownPacketTypes) {
                 console.log("TRACEROUTE_APP", {
+                    to: envelope.packet.to.toString(16),
                     from: envelope.packet.from.toString(16),
+                    want_response: envelope.packet.decoded.wantResponse,
                     route_discovery: routeDiscovery,
                 });
             }
@@ -587,8 +589,8 @@ client.on("message", async (topic, message) => {
             try {
                 await prisma.traceRoute.create({
                     data: {
-                        from_id: envelope.packet.from,
-                        to_id: envelope.packet.to,
+                        to: envelope.packet.to,
+                        from: envelope.packet.from,
                         want_response: envelope.packet.decoded.wantResponse,
                         route: routeDiscovery.route,
                         channel: envelope.packet.channel,

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -587,7 +587,9 @@ client.on("message", async (topic, message) => {
             try {
                 await prisma.traceRoute.create({
                     data: {
-                        node_id: envelope.packet.from,
+                        from_id: envelope.packet.from,
+                        to_id: envelope.packet.to,
+                        want_response: envelope.packet.decoded.wantResponse,
                         route: routeDiscovery.route,
                         channel: envelope.packet.channel,
                         packet_id: envelope.packet.id,

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -894,8 +894,8 @@
                                                 <div class="block flex-1 px-4 py-2">
                                                     <div class="relative flex min-w-0 flex-1 items-center">
                                                         <div>
-                                                            <p class="text-sm font-medium text-gray-900">{{ JSON.parse(traceroute.route).length }} hops {{ traceroute.channel_id ? `on ${traceroute.channel_id}` : '' }}</p>
-                                                            <div class="text-sm text-gray-700">Gated {{ moment(new Date(traceroute.updated_at)).fromNow() }}</div>
+                                                            <p class="text-sm text-gray-900"><span class="font-medium">{{ findNodeById(traceroute.to)?.long_name || '???' }}</span> to <span class="font-medium">{{ findNodeById(traceroute.from)?.long_name || '???' }}</span></p>
+                                                            <div class="text-sm text-gray-700">{{ moment(new Date(traceroute.updated_at)).fromNow() }} - {{ traceroute.route.length }} hops {{ traceroute.channel_id ? `on ${traceroute.channel_id}` : '' }}</div>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -1075,7 +1075,7 @@
                             <div class="flex items-start justify-between">
                                 <div>
                                     <h2 class="font-bold">Traceroute #{{ selectedTraceRoute.id }}</h2>
-                                    <h3 class="text-sm">{{ moment(new Date(selectedTraceRoute.updated_at)).fromNow() }}</h3>
+                                    <h3 class="text-sm">{{ moment(new Date(selectedTraceRoute.updated_at)).fromNow() }} - {{ selectedTraceRoute.route.length }} hops {{ selectedTraceRoute.channel_id ? `on ${selectedTraceRoute.channel_id}` : '' }}</h3>
                                 </div>
                                 <div class="my-auto ml-3 flex h-7 items-center">
                                     <a href="javascript:void(0)" class="rounded-full" @click="selectedTraceRoute = null">
@@ -1098,7 +1098,7 @@
                                 <ul role="list" class="space-y-6">
 
                                     <!-- node that initiated traceroute -->
-                                    <li :onclick="`goToNode(${selectedTraceRoute.node_id})`" class="relative flex gap-x-4">
+                                    <li :onclick="`goToNode(${selectedTraceRoute.to})`" class="relative flex gap-x-4">
                                         <div class="absolute left-0 top-0 flex w-6 justify-center top-6 -bottom-6">
                                             <div class="w-px bg-gray-200"></div>
                                         </div>
@@ -1106,14 +1106,14 @@
                                             <div class="h-4 w-4 rounded-full bg-gray-100 ring-1 ring-gray-300"></div>
                                         </div>
                                         <div class="flex-auto py-0.5 text-sm leading-5 text-gray-500">
-                                            <div class="font-medium text-gray-900">{{ findNodeById(selectedTraceRoute.to_id)?.long_name || '???' }}</div>
-                                            <div>Hex ID: !{{ Number(selectedTraceRoute.to_id).toString(16) }}</div>
+                                            <div class="font-medium text-gray-900">{{ findNodeById(selectedTraceRoute.to)?.long_name || '???' }}</div>
+                                            <div>Hex ID: !{{ Number(selectedTraceRoute.to).toString(16) }}</div>
                                             <div>Started the traceroute</div>
                                         </div>
                                     </li>
 
                                     <!-- middleman nodes -->
-                                    <li :onclick="`goToNode(${route})`" v-for="route of JSON.parse(selectedTraceRoute.route)" class="relative flex gap-x-4">
+                                    <li :onclick="`goToNode(${route})`" v-for="route of selectedTraceRoute.route" class="relative flex gap-x-4">
                                         <div class="absolute left-0 top-0 flex w-6 justify-center -bottom-6">
                                             <div class="w-px bg-gray-200"></div>
                                         </div>
@@ -1127,8 +1127,8 @@
                                         </div>
                                     </li>
 
-                                    <!-- Last node -->
-                                    <li :onclick="`goToNode(${route})`" v-if="selectedTraceRoute.from_id" class="relative flex gap-x-4">
+                                    <!-- node that replied to traceroute -->
+                                    <li :onclick="`goToNode(${route})`" v-if="selectedTraceRoute.from" class="relative flex gap-x-4">
                                         <div class="absolute left-0 top-0 flex w-6 justify-center -bottom-6">
                                             <div class="w-px bg-gray-200"></div>
                                         </div>
@@ -1136,13 +1136,13 @@
                                             <div class="h-4 w-4 rounded-full bg-gray-100 ring-1 ring-gray-300"></div>
                                         </div>
                                         <div class="flex-auto py-0.5 text-sm leading-5 text-gray-500">
-                                            <div class="font-medium text-gray-900">{{ findNodeById(selectedTraceRoute.from_id)?.long_name || '???' }}</div>
-                                            <div>Hex ID: !{{ Number(selectedTraceRoute.from_id).toString(16) }}</div>
+                                            <div class="font-medium text-gray-900">{{ findNodeById(selectedTraceRoute.from)?.long_name || '???' }}</div>
+                                            <div>Hex ID: !{{ Number(selectedTraceRoute.from).toString(16) }}</div>
                                             <div>Replied to traceroute</div>
                                         </div>
                                     </li>
 
-                                    <!-- last node in route -->
+                                    <!-- node that gated traceroute to mqtt -->
                                     <li :onclick="`goToNode(${route})`" v-if="selectedTraceRoute.gateway_id" class="relative flex gap-x-4">
                                         <div class="absolute left-0 top-0 flex w-6 justify-center h-6">
                                             <div class="w-px bg-gray-200"></div>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -894,7 +894,7 @@
                                                 <div class="block flex-1 px-4 py-2">
                                                     <div class="relative flex min-w-0 flex-1 items-center">
                                                         <div>
-                                                            <p class="text-sm font-medium text-gray-900">{{ traceroute.route.length }} hops {{ traceroute.channel_id ? `on ${traceroute.channel_id}` : '' }}</p>
+                                                            <p class="text-sm font-medium text-gray-900">{{ JSON.parse(traceroute.route).length }} hops {{ traceroute.channel_id ? `on ${traceroute.channel_id}` : '' }}</p>
                                                             <div class="text-sm text-gray-700">Gated {{ moment(new Date(traceroute.updated_at)).fromNow() }}</div>
                                                         </div>
                                                     </div>
@@ -1106,14 +1106,14 @@
                                             <div class="h-4 w-4 rounded-full bg-gray-100 ring-1 ring-gray-300"></div>
                                         </div>
                                         <div class="flex-auto py-0.5 text-sm leading-5 text-gray-500">
-                                            <div class="font-medium text-gray-900">{{ findNodeById(selectedTraceRoute.node_id)?.long_name || '???' }}</div>
-                                            <div>Hex ID: !{{ Number(selectedTraceRoute.node_id).toString(16) }}</div>
+                                            <div class="font-medium text-gray-900">{{ findNodeById(selectedTraceRoute.to_id)?.long_name || '???' }}</div>
+                                            <div>Hex ID: !{{ Number(selectedTraceRoute.to_id).toString(16) }}</div>
                                             <div>Started the traceroute</div>
                                         </div>
                                     </li>
 
                                     <!-- middleman nodes -->
-                                    <li :onclick="`goToNode(${route})`" v-for="route of selectedTraceRoute.route" class="relative flex gap-x-4">
+                                    <li :onclick="`goToNode(${route})`" v-for="route of JSON.parse(selectedTraceRoute.route)" class="relative flex gap-x-4">
                                         <div class="absolute left-0 top-0 flex w-6 justify-center -bottom-6">
                                             <div class="w-px bg-gray-200"></div>
                                         </div>
@@ -1124,6 +1124,21 @@
                                             <div class="font-medium text-gray-900">{{ findNodeById(route)?.long_name || '???' }}</div>
                                             <div>Hex ID: !{{ Number(route).toString(16) }}</div>
                                             <div>Forwarded the packet</div>
+                                        </div>
+                                    </li>
+
+                                    <!-- Last node -->
+                                    <li :onclick="`goToNode(${route})`" v-if="selectedTraceRoute.from_id" class="relative flex gap-x-4">
+                                        <div class="absolute left-0 top-0 flex w-6 justify-center -bottom-6">
+                                            <div class="w-px bg-gray-200"></div>
+                                        </div>
+                                        <div class="my-auto relative flex h-6 w-6 flex-none items-center justify-center bg-white">
+                                            <div class="h-4 w-4 rounded-full bg-gray-100 ring-1 ring-gray-300"></div>
+                                        </div>
+                                        <div class="flex-auto py-0.5 text-sm leading-5 text-gray-500">
+                                            <div class="font-medium text-gray-900">{{ findNodeById(selectedTraceRoute.from_id)?.long_name || '???' }}</div>
+                                            <div>Hex ID: !{{ Number(selectedTraceRoute.from_id).toString(16) }}</div>
+                                            <div>Replied to traceroute</div>
                                         </div>
                                     </li>
 


### PR DESCRIPTION
Saves "to", "from" and "want_responce" to the database.
Responses contain the full trace and are from the target to the requester.
Filter on responses where want_response is false and the "to" is the selected node ID,
The hop count can be zero. This is a direct route.
Added the final target to the displayed route list.
Had issues where the route payload was interpreted as a string and not an array of integers. Not sure why. Added JSON.parse() to resolve this,
At time of writing the pull request did not include migration.
Old trace route records are incomplete so could be deleted. There is no record of the trace being outgoing or a reply, which is needed to understand what the node_id in the data means. Also "from" and "to" are needed to understand the trace.
