### PR TITLE
Set voltageChart min y-value to 2V

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1755,7 +1755,7 @@
                             },
                             y: {
                                 display: false, // Hide y-axis labels
-                                min: 0,
+                                min: 2,
                                 max: 5,
                             },
                         },


### PR DESCRIPTION
As mentioned in #13  , voltages on meshtastic devices are typically 3.2-4.2V .  The range on the voltageChart y-axis from 0V to 5V reduced its usefulness as changes within the normal operating range of devices were more difficult to detect.

This patch changes the y-axis range to 2V to 5V. This will improve the resolution for the areas users care about.

Note that this change is more conservative than requested in #13  , as it attempts to take into account less typical voltage. A very drained battery might get around 2V, and 5V might be reported for a USB connection.

fixes #13 