### PR TITLE
Set voltageChart min y-value to 3V

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1755,7 +1755,7 @@
                             },
                             y: {
                                 display: false, // Hide y-axis labels
-                                min: 2,
+                                min: 3,
                                 max: 5,
                             },
                         },


### PR DESCRIPTION
After #23 was merged, spend a couple weeks trying the new graph ranges and felt it could be better.

Quick data analysis supports increasing min voltage to 3v; fewer than 0.1% of nodes have a voltage less than this.

Now set the minimum voltage to 3V.