### PR TITLE
Add 257 ATAK_FORWARDER to ignored packet types

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -720,6 +720,7 @@ client.on("message", async (topic, message) => {
                     || portnum === 65 // ignore STORE_FORWARD_APP
                     || portnum === 66 // ignore RANGE_TEST_APP
                     || portnum === 72 // ignore ATAK_PLUGIN
+                    || portnum === 257 // ignore ATAK_FORWARDER
                 ){
                     return;
                 }

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -721,6 +721,7 @@ client.on("message", async (topic, message) => {
                     || portnum === 66 // ignore RANGE_TEST_APP
                     || portnum === 72 // ignore ATAK_PLUGIN
                     || portnum === 257 // ignore ATAK_FORWARDER
+                    || portnum > 511 // ignore above MAX
                 ){
                     return;
                 }


### PR DESCRIPTION
72 ATAK_PLUGIN was already ignored by Meshtastic Map.

This patch adds 257 ATAK_FORWARDER to the list of ignored packets.