### PR TITLE
Parse traceroute arrays when they don't show up as JSON already

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -417,7 +417,12 @@ app.get('/api/v1/nodes/:nodeId/traceroutes', async (req, res) => {
         const traceroutes = await prisma.$queryRaw`SELECT * FROM traceroutes WHERE want_response = false and \`to\` = ${node.node_id} and gateway_id is not null order by id desc limit ${count}`;
 
         res.json({
-            traceroutes: traceroutes,
+            traceroutes: traceroutes.map((trace) => {
+                if (typeof(trace.route) === "string") {
+                    trace.route = JSON.parse(trace.route);
+                }
+                return trace;
+            }),
         });
 
     } catch(err) {


### PR DESCRIPTION
Without this, for my local installation (and some other private ones I've seen), you'll get traceroutes that show up as impossible numbers of hops and lots of `!NaN` nodeids and things. Basically, if it gets a string instead of a JSON array, it treats each character of the string as a hop in the route. This changes it to parse it to JSON if it gets it from the DB as a string.

I dunno why the DB isn't returning that field as JSON, but it isn't, so this should ensure it works right, anyway!