### PR TITLE
Improve Docker build performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM node:lts-alpine
 
-# add project files to /app
-ADD ./ /app
 WORKDIR /app
 
-# add open ssl
+# Copy only package files and install deps
+# This layer will be cached as long as package*.json don't change
+COPY package*.json package-lock.json* ./
+RUN npm ci
+
+# Copy the rest of your source
+COPY . .
+
 RUN apk add --no-cache openssl
 
-# install node dependencies
-RUN npm install
 
 EXPOSE 8080


### PR DESCRIPTION
Thank you for creating this awesome project, time for me to contribute something back.

- Speed up docker build by caching the dependancies.
- Use `npm ci` instead of `npm install` for reproducible builds
- Added .git to .dockerignore

My build times went from 30+ seconds so about 1 second. 