### PR TITLE
Make docker nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 FROM node:lts-alpine
 
+RUN apk add --no-cache openssl
+
+USER node:node
+
 WORKDIR /app
 
 # Copy only package files and install deps
 # This layer will be cached as long as package*.json don't change
 COPY package*.json package-lock.json* ./
-RUN npm ci
+RUN --mount=type=cache,target=/home/node/.npm,uid=1000,gid=1000 npm ci --omit=dev
 
 # Copy the rest of your source
 COPY . .
-
-RUN apk add --no-cache openssl
 
 
 EXPOSE 8080


### PR DESCRIPTION
Also moves layers around to improve caching, and mount a cache layer for npm packages.
Oh and also don't installs dev deps