### PR TITLE
Add CLIENT_BASE role to roles.json

### DIFF
--- a/src/json/roles.json
+++ b/src/json/roles.json
@@ -10,5 +10,6 @@
   "8": "CLIENT_HIDDEN",
   "9": "LOST_AND_FOUND",
   "10": "TAK_TRACKER",
-  "11": "ROUTER_LATE"
+  "11": "ROUTER_LATE",
+  "12": "CLIENT_BASE"
 }


### PR DESCRIPTION
The `ROUTER_CLIENT` role was deprecated in version [2.3.15](https://github.com/meshtastic/firmware/releases/tag/v2.3.15.deb7c27), but I'm not removing it from the list as there might be older devices still using it. From the documentation those devices are now treated as `CLIENT`

I'm adding the  `CLIENT_BASE` role that is missing. Reference [documentation](https://meshtastic.org/docs/configuration/radio/device/)