### PR TITLE
Update HELTEC_V4 entry in hardware_models.json

### DIFF
--- a/src/json/hardware_models.json
+++ b/src/json/hardware_models.json
@@ -104,6 +104,6 @@
   "102": "T_DECK_PRO",
   "103": "T_LORA_PAGER",
   "104": "GAT562_MESH_TRIAL_TRACKER",
-  "105": "HELTEC_V4", 
+  "110": "HELTEC_V4", 
   "255": "PRIVATE_HW"
 }


### PR DESCRIPTION
Fixes wrong ID for the HELTEC_V4 in my previous PR. 
